### PR TITLE
fix: improve docker config test timeouts and fix .env syntax

### DIFF
--- a/.github/workflows/docker-config-test.yml
+++ b/.github/workflows/docker-config-test.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   docker-compose-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 3  # Overall job timeout
+    timeout-minutes: 10  # Overall job timeout
 
     steps:
     - name: Checkout code
@@ -23,6 +23,7 @@ jobs:
         DB_USER=d-roles
         DB_PASSWORD=d-roles
         DB_SCHEMA=d_roles
+        EOF
 
     - name: Build and start services
       run: make docker &
@@ -30,7 +31,7 @@ jobs:
     - name: Wait for services to be ready
       run: |
         echo "Waiting for app to be ready..."
-        timeout 3m bash -c 'until curl -f http://localhost:80/health; do sleep 2; done'
+        timeout 5m bash -c 'until curl -f http://localhost:80/health; do sleep 2; done'
 
     - name: Run health checks
       run: |


### PR DESCRIPTION
## Summary
- Increase overall job timeout from 3 to 10 minutes to allow sufficient time for Docker builds and startup
- Increase health check wait timeout from 3 to 5 minutes for app readiness
- Fix missing EOF in .env file creation that caused bash syntax error

## Test plan
- [x] Verify workflow syntax is valid
- [x] Test that docker-config-test workflow completes successfully on PR
- [x] Confirm health checks pass within the new timeout limits

Fixes the docker-config-test workflow failures caused by insufficient timeouts and malformed .env file.