### PR TITLE
Fix: Make email sending asynchronous to prevent timeouts

### DIFF
--- a/src/services/groups.py
+++ b/src/services/groups.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import HTTPException, status
 from pydantic import UUID4, EmailStr
 
@@ -199,19 +201,24 @@ class GroupsService:
             )
         )
 
+        # Send email in background task to avoid blocking the response
         if not user.is_verified:
-            await self.email_service.confirmation_email(
-                recipients=[user.email],
-                group_name=group.name,
-                service_provider_name=service_provider.name,
-                service_provider_url=service_provider.url,
+            asyncio.create_task(
+                self.email_service.confirmation_email(
+                    recipients=[user.email],
+                    group_name=group.name,
+                    service_provider_name=service_provider.name,
+                    service_provider_url=service_provider.url,
+                )
             )
         else:
-            await self.email_service.nouveau_groupe_email(
-                recipients=[user.email],
-                group_name=group.name,
-                service_provider_name=service_provider.name,
-                service_provider_url=service_provider.url,
+            asyncio.create_task(
+                self.email_service.nouveau_groupe_email(
+                    recipients=[user.email],
+                    group_name=group.name,
+                    service_provider_name=service_provider.name,
+                    service_provider_url=service_provider.url,
+                )
             )
 
         role = await self.roles_service.get_roles_by_id(role.id)


### PR DESCRIPTION
## Summary

- Fixed production timeout issue when adding users to groups by making email sending asynchronous
- Replaced FastAPI Mail built-in templates with direct Jinja2 rendering for better control
- Email operations now run in background tasks instead of blocking HTTP responses

## Problem

In production, adding a user to a group was causing timeouts. The issue was with mail failure, but it should not block the entire process as users were still being added successfully to the database since the DB transaction completed before email sending.

## Solution

### 1. Asynchronous Email Sending
- Modified `GroupsService.add_user_to_group()` to use `asyncio.create_task()` for email operations
- Emails now send in background while API responds immediately after database operations
- Maintains same functionality but eliminates blocking behavior

### 2. Jinja2 Template Integration
Whats caused the error in the first place is a weird bug in Jinja2 template intégration. Lets do the templating ourself.