### PR TITLE
fix: roles insert in the wrong place

### DIFF
--- a/db/initdb/create.sql
+++ b/db/initdb/create.sql
@@ -102,9 +102,4 @@ CREATE TABLE  IF NOT EXISTS :schema_name.service_accounts (
     CONSTRAINT fk_sa_sp_id FOREIGN KEY (service_provider_id) REFERENCES :schema_name.service_providers (id) ON DELETE CASCADE
 );
 
-INSERT INTO :schema_name.roles (id, role_name, is_admin) VALUES
-(1, 'administrateur', true),
-(2, 'agent', false),
-(3, 'prestataire', false) ON CONFLICT (id) DO NOTHING;
-
 COMMIT;

--- a/db/migrations/20250501.sql
+++ b/db/migrations/20250501.sql
@@ -1,0 +1,6 @@
+
+--  see migration 20250815
+INSERT INTO :schema_name.roles (id, role_name, is_admin) VALUES
+(1, 'administrateur', true),
+(2, 'agent', false),
+(3, 'prestataire', false) ON CONFLICT (id) DO NOTHING;

--- a/db/migrations/20250815.sql
+++ b/db/migrations/20250815.sql
@@ -1,0 +1,17 @@
+\set schema_name :DB_SCHEMA
+
+-- Fourth prestataire remove
+
+-- Issue was, prestataire were seeds in the create.sql as it is metadata,
+-- not an actual seed and therefore used in every environnement.
+
+-- As the create is always run but the migration was only ran once. It would get readded on each following deployment.
+-- With migration 20250501.sql we ensure it gets provisionned right after the create. But it only get run once.
+
+UPDATE :schema_name.group_user_relations
+SET role_id = 2
+WHERE role_id = 3;
+
+-- Remove the "prestataire" role from the roles table
+DELETE FROM :schema_name.roles
+WHERE id = 3;

--- a/db/seed/seed.sql
+++ b/db/seed/seed.sql
@@ -5,6 +5,11 @@
 -- Begin transaction
 BEGIN;
 
+INSERT INTO :schema_name.roles (id, role_name, is_admin) VALUES
+(1, 'administrateur', true),
+(2, 'agent', false) ON CONFLICT (id) DO NOTHING;
+
+
 -- Create an organization for the group
 INSERT INTO :schema_name.organisations (id, name, siret)
 VALUES (1, 'DINUM', '13002526500013') ON CONFLICT (id) DO NOTHING;

--- a/db/seed/seed.sql
+++ b/db/seed/seed.sql
@@ -5,11 +5,6 @@
 -- Begin transaction
 BEGIN;
 
-INSERT INTO :schema_name.roles (id, role_name, is_admin) VALUES
-(1, 'administrateur', true),
-(2, 'agent', false) ON CONFLICT (id) DO NOTHING;
-
-
 -- Create an organization for the group
 INSERT INTO :schema_name.organisations (id, name, siret)
 VALUES (1, 'DINUM', '13002526500013') ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Issue was, roles were seeded in the create.sql as it is a metadata used in every environnement.

As the create.sql is always ran but the migration is only ran once, it would get re-added on each following deployment.

With migration 20250501.sql we ensure it gets provisionned right after the create. But it only get run once.
