### PR TITLE
feat: add a delete group action, for admin only

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -210,6 +210,7 @@ class LOG_ACTIONS(Enum):
     # Group actions
     CREATE_GROUP = "Group created"
     UPDATE_GROUP = "Group updated"
+    DELETE_GROUP = "Group deleted"
 
     # Group membership actions
     ADD_USER_TO_GROUP = "User added to group"

--- a/src/routers/web/admin/pages/groups_view.py
+++ b/src/routers/web/admin/pages/groups_view.py
@@ -60,3 +60,19 @@ async def set_admin(
     await admin_service.set_admin(group_id, user_id)
 
     return RedirectResponse(url=f"/admin/groups/{group_id}", status_code=303)
+
+
+@router.delete("/{group_id}", response_class=RedirectResponse)
+async def delete_group(group_id: int, admin_service=Depends(get_admin_write_service)):
+    """
+    Allow super admin to delete a group and all its related data
+    """
+    if not isinstance(group_id, int) or group_id <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid group ID. It must be a positive integer.",
+        )
+
+    await admin_service.delete_group(group_id)
+
+    return RedirectResponse(url="/admin/groups", status_code=303)

--- a/src/services/admin/write_service.py
+++ b/src/services/admin/write_service.py
@@ -91,3 +91,10 @@ class AdminWriteService:
         return await self.admin_write_repository.update_service_provider(
             service_provider_id, name, url
         )
+
+    async def delete_group(self, group_id: int) -> None:
+        """
+        Delete a group and all its related data.
+        Only super admin can delete groups.
+        """
+        return await self.admin_write_repository.delete_group(group_id)

--- a/templates/pages/admin/group.html
+++ b/templates/pages/admin/group.html
@@ -65,13 +65,28 @@
 
 {% block content %}
 <div class="fr-container">
+  <div class="fr-grid-row fr-grid-row--right">
+      <div class="fr-col-auto">
+        <button type="button"
+                class="fr-btn fr-btn--sm fr-btn--secondary"
+                hx-delete="/admin/groups/{{ details.id }}"
+                hx-confirm="Êtes-vous sûr de vouloir supprimer ce groupe ? Cette action est irréversible et supprimera toutes les données associées (utilisateurs, scopes, etc.)."
+                hx-target="body"
+                hx-push-url="/admin/groups">
+          ⚠️ Supprimer le groupe
+        </button>
+      </div>
+  </div>
   <h2>Informations générales</h2>
-  <ul>
-    <li>Name : {{ details.name }}</li>
-    <li>Creation : {{ details.created_at.strftime('%d/%m/%Y')}} {{ details.created_at.strftime('%H:%M:%S') }}</li>
-    <li>MAJ : {{ details.updated_at.strftime('%d/%m/%Y') }} {{ details.updated_at.strftime('%H:%M:%S') }}</li>
-    <li>Orga : {{details.organisation_name}} ({{ details.organisation_siret }})</li>
-  </ul>
+
+  <div class="fr-container">
+    <ul>
+      <li>Name : {{ details.name }}</li>
+      <li>Creation : {{ details.created_at.strftime('%d/%m/%Y')}} {{ details.created_at.strftime('%H:%M:%S') }}</li>
+      <li>MAJ : {{ details.updated_at.strftime('%d/%m/%Y') }} {{ details.updated_at.strftime('%H:%M:%S') }}</li>
+      <li>Orga : {{details.organisation_name}} ({{ details.organisation_siret }})</li>
+    </ul>
+  </div>
 
   <h2>Droits (scopes)</h2>
   {{ data_table(scopes_headers, scopes, scope_formatter) }}

--- a/templates/pages/admin/group.html
+++ b/templates/pages/admin/group.html
@@ -66,27 +66,25 @@
 {% block content %}
 <div class="fr-container">
   <div class="fr-grid-row fr-grid-row--right">
-      <div class="fr-col-auto">
-        <button type="button"
-                class="fr-btn fr-btn--sm fr-btn--secondary"
-                hx-delete="/admin/groups/{{ details.id }}"
-                hx-confirm="Êtes-vous sûr de vouloir supprimer ce groupe ? Cette action est irréversible et supprimera toutes les données associées (utilisateurs, scopes, etc.)."
-                hx-target="body"
-                hx-push-url="/admin/groups">
+    <div class="fr-col-auto">
+      <button type="button"
+      class="fr-btn fr-btn--sm fr-btn--secondary"
+                  hx-delete="/admin/groups/{{ details.id }}"
+                  hx-confirm="Êtes-vous sûr de vouloir supprimer ce groupe ? Cette action est irréversible et supprimera toutes les données associées (utilisateurs, scopes, etc.)."
+                  hx-target="body"
+                  hx-push-url="/admin/groups">
           ⚠️ Supprimer le groupe
-        </button>
-      </div>
+      </button>
+    </div>
   </div>
   <h2>Informations générales</h2>
 
-  <div class="fr-container">
-    <ul>
-      <li>Name : {{ details.name }}</li>
-      <li>Creation : {{ details.created_at.strftime('%d/%m/%Y')}} {{ details.created_at.strftime('%H:%M:%S') }}</li>
-      <li>MAJ : {{ details.updated_at.strftime('%d/%m/%Y') }} {{ details.updated_at.strftime('%H:%M:%S') }}</li>
-      <li>Orga : {{details.organisation_name}} ({{ details.organisation_siret }})</li>
-    </ul>
-  </div>
+  <ul>
+    <li>Name : {{ details.name }}</li>
+    <li>Creation : {{ details.created_at.strftime('%d/%m/%Y')}} {{ details.created_at.strftime('%H:%M:%S') }}</li>
+    <li>MAJ : {{ details.updated_at.strftime('%d/%m/%Y') }} {{ details.updated_at.strftime('%H:%M:%S') }}</li>
+    <li>Orga : {{details.organisation_name}} ({{ details.organisation_siret }})</li>
+  </ul>
 
   <h2>Droits (scopes)</h2>
   {{ data_table(scopes_headers, scopes, scope_formatter) }}
@@ -98,4 +96,6 @@
   {{ logs_table(logs) }}
 
   <br/>
+</div>
+
 {% endblock %}


### PR DESCRIPTION
This feature introduces the possibility to delete a group. 

Upon deletion : 
- group is deleted along with its scopes etc. 
- users are removed from group, but not deleted

NB : we could add a constraint on group being empty before being deleted. This would avoid unvoluntary group deletion, BUT it would also be more painful to delete groups.

NB 2 : confirmation modal should be enough to avoid unvoluntary deletion

