### PR TITLE
feat: handle webhhoks email specifically

### DIFF
--- a/src/dependencies/datapass.py
+++ b/src/dependencies/datapass.py
@@ -4,7 +4,8 @@ from ..auth.datapass import verified_datapass_signature
 from ..config import settings
 from ..model import DataPassWebhookWrapper
 from ..services.datapass import DatapassService
-from .services import get_groups_service_factory
+from .email import get_email_service
+from .services import get_groups_service_factory, get_users_service
 
 # =============================
 # Datapass webhook dependencies
@@ -26,6 +27,8 @@ async def get_verified_datapass_payload(request: Request):
 
 async def get_datapass_service(
     groups_service_factory=Depends(get_groups_service_factory),
+    email_service=Depends(get_email_service),
+    user_service=Depends(get_users_service),
 ) -> DatapassService:
     """
     Dependency function that provides a DatapassService instance.
@@ -34,6 +37,8 @@ async def get_datapass_service(
     create groups for other service providers.
     """
     datapass_groups_service = groups_service_factory(
-        settings.DATAPASS_SERVICE_PROVIDER_ID
+        settings.DATAPASS_SERVICE_PROVIDER_ID, should_send_emails=False
     )
-    return DatapassService(datapass_groups_service, groups_service_factory)
+    return DatapassService(
+        datapass_groups_service, groups_service_factory, email_service, user_service
+    )

--- a/src/dependencies/services.py
+++ b/src/dependencies/services.py
@@ -109,7 +109,9 @@ async def get_groups_service_factory(
     groups_repository = GroupsRepository(db, logs_service)
     users_in_group_repository = UsersInGroupRepository(db, logs_service)
 
-    def create_groups_service(service_provider_id: int) -> GroupsService:
+    def create_groups_service(
+        service_provider_id: int, should_send_emails=True
+    ) -> GroupsService:
         return GroupsService(
             groups_repository,
             users_in_group_repository,
@@ -118,8 +120,9 @@ async def get_groups_service_factory(
             organisations_service,
             service_provider_service,
             scopes_service,
-            email_service,
             service_provider_id,
+            email_service,
+            should_send_emails=should_send_emails,
         )
 
     return create_groups_service

--- a/src/services/ui/email.py
+++ b/src/services/ui/email.py
@@ -55,10 +55,10 @@ class EmailService:
         self,
         recipients: list[str],
         group_name: str,
-        service_provider_name: str,
+        service_provider_name: str | None,
         service_provider_url: HttpUrl | None,
     ):
-        subject = f"Activation de votre compte {service_provider_name}"
+        subject = f"Activation de votre compte {service_provider_name if service_provider_name is not None else ""}"
         template = "confirmation.html"
 
         context = {

--- a/templates/emails/confirmation.html
+++ b/templates/emails/confirmation.html
@@ -43,11 +43,11 @@
 <body>
   <div class="content">
 
-    <h1>Activation de votre compte {{ service_provider_name }}</h1>
+    <h1>Activation de votre compte {% if service_provider_name %}{{ service_provider_name }}{% endif %}</h1>
 
     <p>Bonjour,</p>
 
-    <p>Vous avez été ajouté(e) au groupe "<i>{{ group_name }}</i>", qui vous donne accès à {% if service_provider_url %}<a href="{{ service_provider_url }}">{{ service_provider_name }}</a>{% else %}{{ service_provider_name }}{% endif %}.</p>
+    <p>Vous avez été ajouté(e) au groupe "<i>{{ group_name }}</i>"{% if service_provider_name %}, qui vous donne accès à {% if service_provider_url %}<a href="{{ service_provider_url }}">{{ service_provider_name }}</a>{% else %}{{ service_provider_name }}{% endif %}{% endif %}.</p>
 
     <p>Pour activer votre compte, cliquez sur le bouton ci-dessous et authentifiez-vous avec votre compte ProConnect :</p>
 


### PR DESCRIPTION
This PR : 
- deactivate default emailings behaviour in webhooks (as Datapass already handle emailing)
- only send an email when user activation is required
